### PR TITLE
Changes needed for Zabbix 7

### DIFF
--- a/html_widget/actions/WidgetView.php
+++ b/html_widget/actions/WidgetView.php
@@ -1,5 +1,5 @@
 <?php
-namespace Modules\ShrankHtmlWidget\Actions;
+namespace Widgets\ShrankHtmlWidget\Actions;
 use CControllerDashboardWidgetView,
     CControllerResponseData; 
 class WidgetView extends CControllerDashboardWidgetView {

--- a/html_widget/includes/WidgetForm.php
+++ b/html_widget/includes/WidgetForm.php
@@ -1,5 +1,5 @@
 <?php 
-namespace Modules\ShrankHtmlWidget\Includes; 
+namespace Widgets\ShrankHtmlWidget\Includes; 
 use Zabbix\Widgets\CWidgetForm; 
 use Zabbix\Widgets\Fields\CWidgetFieldTextArea; 
 class WidgetForm extends CWidgetForm {

--- a/html_widget/manifest.json
+++ b/html_widget/manifest.json
@@ -4,6 +4,7 @@
   "type": "widget",
   "name": "HTML",
   "namespace": "ShrankHtmlWidget",
+  "description": "Displays plain html content.",
   "version": "1.0",
   "author": "shrank",
   "actions": {


### PR DESCRIPTION
The folder name for widgets changed from 'Modules' to 'Widgets' in Zabbix 7